### PR TITLE
Add baseDir to testdata paths and update container path

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -17,8 +17,8 @@ params {
   
   // Input data
   input = ['https://github.com/nf-core/test-datasets/raw/eager/testdata/Mammoth/bam/JK2782_TGGCCGATCAACGA_L008_R1_001.fastq.gz.tengrand.fq.combined.fq.mapped.bam',
-           'testdata/First_SmallTest_Paired.bam',
-           'testdata/Second_SmallTest_Paired.bam',
-           'testdata/wgEncodeUwRepliSeqK562G1AlnRep1.bam'
+           "$baseDir/testdata/First_SmallTest_Paired.bam",
+           "$baseDir/testdata/Second_SmallTest_Paired.bam",
+           "$baseDir/testdata/wgEncodeUwRepliSeqK562G1AlnRep1.bam"
           ] 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,7 +36,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'qbic-pipelines/bamtofastq:dev'
+process.container = 'qbicpipelines/bamtofastq:dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'


### PR DESCRIPTION
When testing to pull the code from github (`nextflow run qbic-pipelines/bamtofastq -profile test,singularity`), I noticed that the test files weren't found. So I added `baseDir` to the paths. 

Also updated the container path. 

