### PR TITLE
Use published CRAM test data

### DIFF
--- a/conf/test_cram.config
+++ b/conf/test_cram.config
@@ -18,8 +18,8 @@ params {
 
   cram_files = true
   input = [
-          'https://raw.githubusercontent.com/BrunoGrandePhD/bamtofastq/master/testdata/First_SmallTest_Paired.cram',
-          'https://raw.githubusercontent.com/BrunoGrandePhD/bamtofastq/master/testdata/Second_SmallTest_Paired.cram'
+          'https://raw.githubusercontent.com/qbic-pipelines/bamtofastq/master/testdata/First_SmallTest_Paired.cram',
+          'https://raw.githubusercontent.com/qbic-pipelines/bamtofastq/master/testdata/Second_SmallTest_Paired.cram'
           ]
   reference_fasta = 'ftp://ftp.broadinstitute.org/pub/seq/references/Homo_sapiens_assembly19.fasta'
 }


### PR DESCRIPTION
This PR should be merged after #37, _i.e._ once the test CRAM files are "published" to `master`. 

Depends on #37 